### PR TITLE
Fix demo. Clear addons list on terminal recreation

### DIFF
--- a/demo/client.ts
+++ b/demo/client.ts
@@ -392,7 +392,9 @@ function initAddons(term: TerminalType): void {
     wrapper.appendChild(label);
     fragment.appendChild(wrapper);
   });
-  document.getElementById('addons-container').appendChild(fragment);
+  const container = document.getElementById('addons-container');
+  container.innerHTML = '';
+  container.appendChild(fragment);
 }
 
 function addDomListener(element: HTMLElement, type: string, handler: (...args: any[]) => any): void {


### PR DESCRIPTION
Steps to reproduce:
1. Run demo
2. Click `Dispose terminal`
3. Click `Recreate Terminal`

Observe addons list in `#addons-container`.